### PR TITLE
API endpoint and test for listing all inventory records

### DIFF
--- a/service/routes.py
+++ b/service/routes.py
@@ -67,7 +67,16 @@ def create_inventory_records():
     #return jsonify(inventory.serialize()), status.HTTP_201_CREATED
     return jsonify(inventory.serialize()), status.HTTP_201_CREATED, {"Location": location_url}
     
-   
+
+@app.route("/inventory-records", methods=["GET"])
+def list_inventory_records():
+    """Returns all of the Inventory records"""
+    app.logger.info("Request list of inventory records")
+    records = Inventory.all()
+    results = [record.serialize() for record in records]
+    app.logger.info("Returning %d inventory records", len(results))
+    return jsonify(results), status.HTTP_200_OK
+
 ######################################################################
 #  U T I L I T Y   F U N C T I O N S
 ######################################################################
@@ -90,8 +99,3 @@ def check_content_type(content_type):
         status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
         f"Content-Type must be {content_type}",
     )
-
-
-    
-
-    

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -90,6 +90,18 @@ class TestInventory(TestCase):
         self.assertEqual(new_record["reorder_quantity"], test_record.reorder_quantity)
         self.assertEqual(new_record["restock_level"], test_record.restock_level)
 
+        #uncomment this once list all products works
+        #Check that the location header was correct
+        # response = self.client.get(location)
+        # self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # new_record = response.get_json()
+        #self.assertEqual(new_record["id"], test_record.id)
+        # self.assertEqual(new_record["name"], test_record.name)
+        # self.assertEqual(new_record["condition"], test_record.condition.value)
+        # self.assertEqual(new_record["quantity"], test_record.quantity)
+        # self.assertEqual(new_record["reorder_quantity"], test_record.reorder_quantity)
+        # self.assertEqual(new_record["restock_level"], test_record.restock_level)
+
     def test_create_alreadyexists_record(self):
         """Test if a record already exists"""
         

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -90,18 +90,6 @@ class TestInventory(TestCase):
         self.assertEqual(new_record["reorder_quantity"], test_record.reorder_quantity)
         self.assertEqual(new_record["restock_level"], test_record.restock_level)
 
-        #uncomment this once list all products works
-        #Check that the location header was correct
-        # response = self.client.get(location)
-        # self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # new_record = response.get_json()
-        #self.assertEqual(new_record["id"], test_record.id)
-        # self.assertEqual(new_record["name"], test_record.name)
-        # self.assertEqual(new_record["condition"], test_record.condition.value)
-        # self.assertEqual(new_record["quantity"], test_record.quantity)
-        # self.assertEqual(new_record["reorder_quantity"], test_record.reorder_quantity)
-        # self.assertEqual(new_record["restock_level"], test_record.restock_level)
-
     def test_create_alreadyexists_record(self):
         """Test if a record already exists"""
         

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -51,6 +51,15 @@ class TestInventory(TestCase):
         """ This runs after each test """
         db.session.remove()
 
+    def _create_inventory_records(self, count):
+        """Factory method to create inventory records in bulk"""
+        records = []
+        for _ in range(count):
+            test_record = InventoryFactory()
+            response = self.client.post(BASE_URL, json=test_record.serialize())
+            self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+            records.append(test_record)
+        return records
 
     ######################################################################
     #  P L A C E   T E S T   C A S E S   H E R E
@@ -140,4 +149,12 @@ class TestInventory(TestCase):
         #this will test when a string is passed which has invalid request headers
         response = self.client.post(BASE_URL, data="1")
         self.assertEqual(response.status_code, status.HTTP_415_UNSUPPORTED_MEDIA_TYPE)
-    
+
+    def test_list_inventory_records(self):
+        expected_records = self._create_inventory_records(5)
+        expected_response = [record.serialize() for record in expected_records]
+        response = self.client.get(BASE_URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.get_json()
+        self.assertEqual(len(data), 5)
+        self.assertCountEqual(expected_response, data)


### PR DESCRIPTION
- Route for listing all inventory records. `GET /inventory-records`.
- Test for
    - Asserting count of listed records.
    - Asserting values of listed records (irrespective of order)