### PR TITLE
Enable optional params in API request body

### DIFF
--- a/service/models.py
+++ b/service/models.py
@@ -79,7 +79,7 @@ class Inventory(db.Model):
         return {
             "product_id": self.product_id,
             "name": self.name,
-            "condition": self.condition.value,
+            "condition": self.condition and self.condition.value,
             "quantity": self.quantity,
             "reorder_quantity": self.reorder_quantity,
             "restock_level": self.restock_level
@@ -94,11 +94,20 @@ class Inventory(db.Model):
         """
         try:
             self.product_id=data["product_id"]
-            self.name = data["name"]
             self.condition = self.Condition(data["condition"])
-            self.quantity = data["quantity"]
-            self.reorder_quantity = data["reorder_quantity"]
-            self.restock_level = data["restock_level"]
+
+            if "name" in data and data["name"] is not None:
+                self.name = data["name"]
+
+            if "quantity" in data and data["quantity"] is not None:
+                self.quantity = data["quantity"]
+
+            if "reorder_quantity" in data and data["reorder_quantity"] is not None:
+                self.reorder_quantity = data["reorder_quantity"]
+
+            if "restock_level" in data and data["restock_level"] is not None:
+                self.restock_level = data["restock_level"]
+
         except KeyError as error:
             raise DataValidationError(
                 "Invalid Inventory: missing " + error.args[0]

--- a/service/models.py
+++ b/service/models.py
@@ -79,7 +79,7 @@ class Inventory(db.Model):
         return {
             "product_id": self.product_id,
             "name": self.name,
-            "condition": self.condition and self.condition.value,
+            "condition": self.condition.value,
             "quantity": self.quantity,
             "reorder_quantity": self.reorder_quantity,
             "restock_level": self.restock_level

--- a/service/routes.py
+++ b/service/routes.py
@@ -64,8 +64,12 @@ def create_inventory_records():
     app.logger.info("Request to create a record")
     check_content_type("application/json")
     inventory = Inventory()
-    inventory.deserialize(request.get_json())
+    data = request.get_json()
 
+    if "condition" not in data or data["condition"] is None:
+        data["condition"] = "new"
+
+    inventory.deserialize(data)
     product=inventory.find((inventory.product_id,inventory.condition))
     if product:
         abort(status.HTTP_409_CONFLICT, f"Product with id '{inventory.product_id}' and condition '{inventory.condition} 'already exists.")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -91,6 +91,21 @@ class TestInventory(unittest.TestCase):
         self.assertEqual(record.reorder_quantity, 20)
         self.assertEqual(record.restock_level, 2)
 
+    def test_inventory_deserialize_partial_fields(self):
+        data = {
+            "product_id": 1,
+            "condition": Inventory.Condition.RETURN.value
+        }
+        record = Inventory()
+        record.deserialize(data)
+        self.assertEqual(record.product_id, 1)
+        self.assertEqual(record.condition, Inventory.Condition.RETURN)
+        self.assertEqual(record.name, None)
+        self.assertEqual(record.quantity, None)
+        self.assertEqual(record.reorder_quantity, None)
+        self.assertEqual(record.restock_level, None)
+
+
     def test_invalid_inventory_deserialize(self):
         data = {}
         record = Inventory()


### PR DESCRIPTION
- `condition` defaults to `NEW` in `POST /inventory-records`, when not provided in the `body`.
- `quantity`, `reorder_quantity`, `restock_level` defaults to `0` for
    - `DELETE /inventory-records/<product_id>`
    - `PUT //inventory-records/<product_id>`
    - `GET /inventory-records/<product_id>`
- Updated `deserialize` and `serialize` functions in model to reflect the default behavior.
- Added tests for
    - Deserialization when optional fields are absent.
    - Create records when optional fields are absent.
- Updated tests for delete inventory records to include only essential fields in the request body.